### PR TITLE
[DPLA-12] modify MTSU transforms for intermediate provider

### DIFF
--- a/XSLT/mtsuDCtoMODS.xsl
+++ b/XSLT/mtsuDCtoMODS.xsl
@@ -539,13 +539,57 @@
     </xsl:template>
     
     <xsl:template name="recordSource">
+        <!--
+      	weird issue(s?) with the logic in the following xsl:if; specific to the in-REPOX transform, i.e. works fine externally
+      	using the saxon-8.7.jar. leaving the original commented for now.
+      -->
+        <!--<xsl:if
+							test="
+									(count(dc:publisher) >= 2) and
+									(some $pub in dc:publisher
+											satisfies not(matches(., 'Digital Initiatives, James E. Walker Library, Middle Tennessee State University')))">-->
+        <xsl:if test="count(dc:publisher) >= 2">
+            <note displayLabel="Intermediate Provider">Digital Initiatives, James E. Walker Library,
+                Middle Tennessee State University</note>
+        </xsl:if>
+        <!--</xsl:if>-->
         <recordInfo>
-            <recordContentSource>Middle Tennessee State University</recordContentSource>
-            <recordChangeDate><xsl:value-of select="current-date()"/></recordChangeDate>
+            <xsl:for-each select="dc:publisher">
+                <xsl:choose>
+                    <xsl:when
+                            test=".[starts-with(., 'Digital Initiatives')] and count(dc:publisher) = 1">
+                        <recordContentSource>
+                            <xsl:value-of select="."/>
+                        </recordContentSource>
+                    </xsl:when>
+                    <xsl:when test="matches(., 'Murfreesboro, TN') or
+				                            contains(normalize-space(lower-case(.)), 'albert gore') or
+				                            contains(normalize-space(lower-case(.)), 'arts center') or
+				                            contains(normalize-space(lower-case(.)), 'center for historic preservation') or
+				                            contains(normalize-space(lower-case(.)), 'tennessee state library')">
+                        <recordContentSource>
+                            <xsl:value-of select="."/>
+                        </recordContentSource>
+                    </xsl:when>
+                    <xsl:when test="count(dc:publisher) = 1">
+                        <recordContentSource>
+                            <xsl:value-of select="."/>
+                        </recordContentSource>
+                    </xsl:when>
+                </xsl:choose>
+            </xsl:for-each>
+            <recordChangeDate>
+                <xsl:value-of select="current-date()"/>
+            </recordChangeDate>
             <languageOfCataloging>
                 <languageTerm type="code" authority="iso639-2b">eng</languageTerm>
             </languageOfCataloging>
-            <recordOrigin>Record has been transformed into MODS 3.5 from a qualified Dublin Core record by the Digital Library of Tennessee, a service hub of the Digital Public Library of America, using a stylesheet available at https://github.com/cmh2166/DLTN. Metadata originally created in a locally modified version of qualified Dublin Core using ContentDM (data dictionary available: https://wiki.lib.utk.edu/display/DPLA.)</recordOrigin>
+            <recordOrigin>Record has been transformed into MODS 3.5 from a qualified Dublin Core
+                record by the Digital Library of Tennessee, a service hub of the Digital Public
+                Library of America, using a stylesheet available at https://github.com/utkdigitalinitiatives/DLTN.
+                Metadata originally created in a locally modified version of qualified Dublin Core
+                using ContentDM (data dictionary available:
+                https://wiki.lib.utk.edu/display/DPLA.)</recordOrigin>
         </recordInfo>
     </xsl:template>
     

--- a/XSLT/mtsuDCtoMODS.xsl
+++ b/XSLT/mtsuDCtoMODS.xsl
@@ -554,24 +554,20 @@
         </xsl:if>
         <!--</xsl:if>-->
         <recordInfo>
+            <xsl:variable name="pub-count" select="count(dc:publisher)"/>
             <xsl:for-each select="dc:publisher">
                 <xsl:choose>
-                    <xsl:when
-                            test=".[starts-with(., 'Digital Initiatives')] and count(dc:publisher) = 1">
+                    <xsl:when test=".[starts-with(., 'Digital Initiatives')] and $pub-count = 1">
                         <recordContentSource>
                             <xsl:value-of select="."/>
                         </recordContentSource>
                     </xsl:when>
-                    <xsl:when test="matches(., 'Murfreesboro, TN') or
-				                            contains(normalize-space(lower-case(.)), 'albert gore') or
-				                            contains(normalize-space(lower-case(.)), 'arts center') or
-				                            contains(normalize-space(lower-case(.)), 'center for historic preservation') or
-				                            contains(normalize-space(lower-case(.)), 'tennessee state library')">
+                    <xsl:when test=".[not(starts-with(., 'Digital Initiatives'))] and $pub-count > 1">
                         <recordContentSource>
-                            <xsl:value-of select="."/>
+                            <xsl:value-of select=".[not(starts-with(., 'Digitial Initiatives'))]"/>
                         </recordContentSource>
                     </xsl:when>
-                    <xsl:when test="count(dc:publisher) = 1">
+                    <xsl:when test="$pub-count = 1">
                         <recordContentSource>
                             <xsl:value-of select="."/>
                         </recordContentSource>

--- a/XSLT/mtsubuchananDCtoMODS.xsl
+++ b/XSLT/mtsubuchananDCtoMODS.xsl
@@ -15,7 +15,6 @@
             xmlns="http://www.loc.gov/mods/v3" version="3.5" 
             xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
             <xsl:apply-templates select="dc:title"/> <!-- titleInfo/title and part/detail|date parsed out -->
-            <xsl:apply-templates select="dc:identifier" mode="part"/>
             <xsl:apply-templates select="dc:identifier"/> <!-- identifier -->
             <xsl:apply-templates select="dc:contributor" /> <!-- name/role -->
             <xsl:apply-templates select="dc:creator" /> <!-- name/role -->

--- a/XSLT/mtsup15838coll7DCtoMODS.xsl
+++ b/XSLT/mtsup15838coll7DCtoMODS.xsl
@@ -14,7 +14,6 @@
             xmlns="http://www.loc.gov/mods/v3" version="3.5" 
             xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
             <xsl:apply-templates select="dc:title"/> <!-- titleInfo/title and part/detail|date parsed out -->
-            <xsl:apply-templates select="dc:identifier" mode="part"/>
             <xsl:apply-templates select="dc:identifier"/> <!-- identifier -->
             <xsl:apply-templates select="dc:contributor" /> <!-- name/role -->
             <xsl:apply-templates select="dc:creator" /> <!-- name/role -->

--- a/XSLT/mtsurchsDCtoMODS.xsl
+++ b/XSLT/mtsurchsDCtoMODS.xsl
@@ -14,7 +14,6 @@
             xmlns="http://www.loc.gov/mods/v3" version="3.5" 
             xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
             <xsl:apply-templates select="dc:title"/> <!-- titleInfo/title and part/detail|date parsed out -->
-            <xsl:apply-templates select="dc:identifier" mode="part"/>
             <xsl:apply-templates select="dc:identifier"/> <!-- identifier -->
             <xsl:apply-templates select="dc:contributor" /> <!-- name/role -->
             <xsl:apply-templates select="dc:creator" /> <!-- name/role -->

--- a/XSLT/mtsuschoolsDCtoMODS.xsl
+++ b/XSLT/mtsuschoolsDCtoMODS.xsl
@@ -14,7 +14,6 @@
             xmlns="http://www.loc.gov/mods/v3" version="3.5" 
             xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
             <xsl:apply-templates select="dc:title"/> <!-- titleInfo/title and part/detail|date parsed out -->
-            <xsl:apply-templates select="dc:identifier" mode="part"/>
             <xsl:apply-templates select="dc:identifier"/> <!-- identifier -->
             <xsl:apply-templates select="dc:contributor" /> <!-- name/role -->
             <xsl:apply-templates select="dc:creator" /> <!-- name/role -->

--- a/XSLT/mtsushadesDCtoMODS.xsl
+++ b/XSLT/mtsushadesDCtoMODS.xsl
@@ -14,7 +14,6 @@
             xmlns="http://www.loc.gov/mods/v3" version="3.5" 
             xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd">
             <xsl:apply-templates select="dc:title"/> <!-- titleInfo/title and part/detail|date parsed out -->
-            <xsl:apply-templates select="dc:identifier" mode="part"/>
             <xsl:apply-templates select="dc:identifier"/> <!-- identifier -->
             <xsl:apply-templates select="dc:contributor" /> <!-- name/role -->
             <xsl:apply-templates select="dc:creator" /> <!-- name/role -->


### PR DESCRIPTION
This PR updates the recordSource template to correctly process dc:publisher>recordContentSource|note@Intermediate Provider. Additionally, this PR removes an unnecessary mode swith from several collection-level stylesheets.