### PR TITLE
Update Crossroads Fedora DNS.

### DIFF
--- a/XSLT/thumbnailsFedoraDCtoMODS.xsl
+++ b/XSLT/thumbnailsFedoraDCtoMODS.xsl
@@ -11,7 +11,7 @@
         <xsl:if test="starts-with($idvalue,'rds:')"> 
             <!-- Crossroads Fedora puts the PID in an <identifier> field in the OAI record --><!-- process Fedora thumbnail urls -->           
             <xsl:variable name="PID" select="substring-after($idvalue,'rds:')"/>
-            <url access="preview"><xsl:value-of select="concat('http://crossroads.rhodes.edu:9090/fedora/get/rds:',$PID,'/thumbnail_100x75.jpg')"/></url> <!--CONTENTdm thumbnail url-->
+            <url access="preview"><xsl:value-of select="concat('http://fedora.crossroadstofreedom.org/fedora/get/rds:',$PID,'/thumbnail_100x75.jpg')"/></url> <!--CONTENTdm thumbnail url-->
         </xsl:if>
     </xsl:template>
     


### PR DESCRIPTION
*JIRA TICKET* - [DPLA-33](https://jira.lib.utk.edu/browse/DPLA-33)

# What Does this Pull Request Do

While working on [DLTN Flask](https://github.com/markpbaggett/dltn_flask), my students noticed none of the Crossroads to Freedom thumbnails were loading.  After doing some digging, it became apparent that the domain changed.  This updates the domain name.

See:

* [Fedora response](http://fedora.crossroadstofreedom.org/fedora/get/rds:45372/)
* [Thumbnail example](http://fedora.crossroadstofreedom.org/fedora/get/rds:105679/thumbnail_100x75.jpg)

# How Should This Be Tested

1. cp current transform on dpla.lib.utk.edu to *.bak. 
2. Mv this transform to the directory remembering that case is different.  
3. Touch all files in directory.
4. Look at the MODS metadata prefix and see if the first few /mods/location/url[@type='object in context'] resolve.

# Interested Parties

@CanOfBees 
@kzayasru 