### PR TITLE
Address Issue #11.

### DIFF
--- a/XSLT/memphisDCtoMODS.xsl
+++ b/XSLT/memphisDCtoMODS.xsl
@@ -34,6 +34,7 @@
                         <xsl:for-each select="tokenize(normalize-space(.), '&lt;br&gt;')">
                             <xsl:if test="normalize-space(.)!=''">
                                 <xsl:choose>
+                                    <xsl:when test="starts-with(normalize-space(.), 'Description by')"/>
                                     <xsl:when test="contains(normalize-space(.), 'additional research by')">
                                         <name>
                                             <namePart><xsl:value-of select="replace(normalize-space(.), 'additional research by ', '')"/></namePart>


### PR DESCRIPTION
**GitHub Issue**: [Issue 11](https://github.com/utkdigitalinitiatives/DLTN/issues/11)

## What does this Pull Request do?

Removes any dc:contributors from Memphis that start with "Description by".

## What's new?

* Added a when statement to the dc:contributor choose to look for things that start with "Description by"
* Note:  I decided there was little to no benefit of this stuff getting mapped to MODS as a marcrelator since it ultimately won't make it in DPLA.
## How should this be tested?

A description of what steps someone could take to:

* Does the transform validate in Oxygen using th Saxon 8.7 processor
* Using sample XML code, does the pull request doe what is intended
* If you have access to a Repox instance, does applying the pull request and touching all existing XSLT do what is intended.
* If you run a full Scema validation on the feed the transform(s) applies to(using Variety.js and DLTN Metadata QA), does every record have:
	* a titleInfo/title
	* a location/url
	* an accessCondition

## Additional Notes:

This is already live on dpla.lib.utk.edu/repox

## Interested parties

@CanOfBees 